### PR TITLE
Add "prefer-stable": true

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,5 +23,6 @@
             "vendor/redbeanphp/rb.php"
 	    ]
 	},
-	"minimum-stability": "dev"
+	"minimum-stability": "dev",
+	"prefer-stable": true
 }


### PR DESCRIPTION
I think it would be a good idea to set "prefer-stable": true, in the composer.json.
We probably shouldn't be using dev for any other bundles/packages, atleast not by default since the default for [minimum-stability][1] is stable.

[1]: https://getcomposer.org/doc/04-schema.md#minimum-stability