### PR TITLE
update require section to use @dev version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     ],
     
     "require": {
-        "redbeanphp": "master"
+        "redbeanphp": "master@dev"
     },
 	
 	"autoload": {
@@ -23,6 +23,4 @@
             "vendor/redbeanphp/rb.php"
 	    ]
 	},
-	"minimum-stability": "dev",
-	"prefer-stable": true
 }


### PR DESCRIPTION
No more need to specify min-stability and prefered stabilty.

So we can choose what min-stabilty we wish and prefered stability too.